### PR TITLE
全ての右辺値参照を削除しました。

### DIFF
--- a/mogupro/game/include/Network/cUDP.h
+++ b/mogupro/game/include/Network/cUDP.h
@@ -24,7 +24,7 @@ public:
     bool emptyChunk( );
     // 古いデータから返します。
     // その時に一緒にそのデータは削除されます。
-    cPacketChunk&& popChunk( );
+    cPacketChunk popChunk( );
 private:
     void receive( );
 private:

--- a/mogupro/game/src/Network/cUDP.cpp
+++ b/mogupro/game/src/Network/cUDP.cpp
@@ -76,12 +76,12 @@ bool cUDP::emptyChunk( )
     Utility::cScopedMutex m( mMutex );
     return mChacheEndpoints.empty( );
 }
-cPacketChunk&& cUDP::popChunk( )
+cPacketChunk cUDP::popChunk( )
 {
     Utility::cScopedMutex m( mMutex );
     auto front = mChacheEndpoints.front( );
     mChacheEndpoints.pop_front( );
-    return std::move( front );
+    return front;
 }
 void cUDP::receive( )
 {

--- a/mogupro/game/src/Network/cUDPManager.cpp
+++ b/mogupro/game/src/Network/cUDPManager.cpp
@@ -21,7 +21,7 @@ void cUDPManager::update( )
 {
     while ( !mSocket.emptyChunk( ) )
     {
-        auto&& chunk = mSocket.popChunk( );
+        auto chunk = mSocket.popChunk( );
         onReceive( chunk );
     }
 


### PR DESCRIPTION
moveは関数内で宣言された変数の寿命を移せないらしいです。